### PR TITLE
Fix requirements erroring out in build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-django>=4.2.11, <=4.3  # 4.2 is the Long-Term Service version until 2026.
+django>=4.2.11,<=4.3  # 4.2 is the Long-Term Service version until 2026.
 psycopg2==2.*
-requests>=2.31.*, <3.0
-djangorestframework>=3.14.*, <4.0
+requests>=2.31,<3.0
+djangorestframework>=3.14,<4.0
 pyjwt[crypto]>=2.8.0
 pillow==10.*
 python-lzo==1.15


### PR DESCRIPTION
Fixes this
```
1.113 ERROR: Invalid requirement: 'requests>=2.31.*, <3.0': .* suffix can only be used with `==` or `!=` operators
1.113     requests>=2.31.*, <3.0
1.113             ~~~~~~~^ (from line 3 of requirements.txt)
```